### PR TITLE
Add Adobe Photoshop Document (psd) to compressed extensions list

### DIFF
--- a/Duplicati/Library/Main/default_compressed_extensions.txt
+++ b/Duplicati/Library/Main/default_compressed_extensions.txt
@@ -98,6 +98,7 @@
 .dng #Adobe Digital Negative
 .cr2 #Canon RAW Image Format
 .webp #WebP Image
+.psd #Adobe Photoshop Document
 
 
 # Compressed Font files


### PR DESCRIPTION
This format does not seem to compress at all. Add it to the list of compressed image formats.